### PR TITLE
Adding error notifications

### DIFF
--- a/perspective.moon
+++ b/perspective.moon
@@ -1,7 +1,7 @@
 script_name="Perspective"
-script_description="Zeght's perspective.py but in moonscript"
+script_description="Zeght's perspective.py but in moonscript by Alendt, with a few tweaks from Zahuczky"
 script_author=""
-script_version="1.0"
+script_version="1.1"
 
 class Point
 	new: (@x, @y, @z) =>
@@ -102,17 +102,20 @@ unrot = (coord_in, org, diag, get_rot) -> --diag=true, get_rot=false
 	fry = math.atan(n.x/n.z)
 	s = ""
 	s = s.."\\fry"..round((-fry / math.pi * 180), 2)
+	export debfry = round((-fry / math.pi * 180), 2)
 	rot_n = n\rot_y(fry)
 	frx = -math.atan(rot_n.y/rot_n.z)
 	if n0.z < 0
 		frx += math.pi
 	s = s.."\\frx"..round((-frx / math.pi * 180), 2)
+	export debfrx = round((-frx / math.pi * 180), 2)
 	n = vector(a, b)
 	ab_unrot = vector(a, b)\rot_y(fry)\rot_x(frx)
 	ac_unrot = vector(a, c)\rot_y(fry)\rot_x(frx)
 	ad_unrot = vector(a, d)\rot_y(fry)\rot_x(frx)
 	frz = math.atan2(ab_unrot.y, ab_unrot.x)
 	s = s.."\\frz"..round((-frz / math.pi * 180), 2)
+	export debfrz = round((-frz / math.pi * 180), 2)
 	ad_unrot = ad_unrot\rot_z(frz)
 	fax = ad_unrot.x/ad_unrot.y
 	if math.abs(fax) > 0.01
@@ -290,7 +293,7 @@ perspective = (line, tr_org, tr_center, tr_ratio) ->
 		if tf_tags == nil
 			aegisub.log(tf_tags)
 		else
-			return "\\org("..target_org.x..","..target_org.y..")"..tf_tags
+			return ""..tf_tags
 			
 	if count_e(rots) == 0
 		aegisub.log("No proper perspective found.")
@@ -356,6 +359,11 @@ aegi1 = (sub, sel) ->
 		line.text = delete_old_tag(line)
 		line.text = line.text\gsub("\\clip", result.."\\clip")
 		sub[li] = line
+	if debfry > 90 and debfry < 270 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfry > -270 and debfry < -90 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrx > 90 and debfrx < 270 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrx > -270 and debfrx < -90 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrz > 90 or debfrz < -90 aegisub.debug.out("Uh-oh! Seems like your text was rotated a lot! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
 
 aegi2 = (sub, sel) ->
 	for si, li in ipairs(sel)
@@ -364,6 +372,11 @@ aegi2 = (sub, sel) ->
 		line.text = delete_old_tag(line)
 		line.text = line.text\gsub("\\clip", result.."\\clip")
 		sub[li] = line
+	if debfry > 90 and debfry < 270 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfry > -270 and debfry < -90 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrx > 90 and debfrx < 270 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrx > -270 and debfrx < -90 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrz > 90 or debfrz < -90 aegisub.debug.out("Uh-oh! Seems like your text was rotated a lot! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
 
 aegi3 = (sub, sel) ->
 	for si, li in ipairs(sel)
@@ -372,6 +385,11 @@ aegi3 = (sub, sel) ->
 		line.text = delete_old_tag(line)
 		line.text = line.text\gsub("\\clip", result.."\\clip")
 		sub[li] = line
+	if debfry > 90 and debfry < 270 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfry > -270 and debfry < -90 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrx > 90 and debfrx < 270 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrx > -270 and debfrx < -90 aegisub.debug.out("Uh-oh! Seems like your text was mirrored! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
+	elseif debfrz > 90 or debfrz < -90 aegisub.debug.out("Uh-oh! Seems like your text was rotated a lot! Are you sure that's what you wanted? Here's a reminder: You need to draw your clip in a manner, where the first point of your clip is the upper left, then going clockwise from there.")
 
 aegisub.register_macro("Perspective/Transform for target org", "Transform for target org", aegi1)
 aegisub.register_macro("Perspective/Transforms near center of tetragon", "Transforms near center of tetragon", aegi2)


### PR DESCRIPTION
If the text is rotated or mirrored in a way that indicates that the user most likely drawn the clip in a wrong order, a notification dialogue box pops up warning them of it, and clarifies the use of the script. 
For example, if the text is rotated over 90 degrees, or mirrored in any direction.
If the text seems okay, no notification is showed. 